### PR TITLE
libjpeg: Disable WPO on MSVC for all build types

### DIFF
--- a/recipes/libjpeg/all/conanfile.py
+++ b/recipes/libjpeg/all/conanfile.py
@@ -117,6 +117,9 @@ class LibjpegConan(ConanFile):
                     f"""<Import Project="{conantoolchain_props}" /><Import Project="$(VCTargetsPath)\\Microsoft.Cpp.props" />""",
                 )
 
+                # disable whole program optimization in all builds
+                replace_in_file(self, jpeg_vcxproj, "<WholeProgramOptimization>true", "<WholeProgramOptimization>False")
+
                 # Patch settings for a different build type
                 if self.settings.build_type is not "Release":
                     replacements = {
@@ -125,7 +128,6 @@ class LibjpegConan(ConanFile):
                     if self.settings.build_type == "Debug":
                         replacements.update({
                             "<Optimization>Full": "<Optimization>Disabled",
-                            "<WholeProgramOptimization>true": "<WholeProgramOptimization>False",
                             "NDEBUG;": "_DEBUG;",
                         })
                     for key, value in replacements.items():


### PR DESCRIPTION
Disable "Whole Program Optimization" for all build types on MSVC, not just for Debug.
This should fix #24116

Specify library name and version:  **libjpeg/ANY**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->
